### PR TITLE
Separated "transform sx and sh"

### DIFF
--- a/AWS/version
+++ b/AWS/version
@@ -1,4 +1,4 @@
 {
-    "version": "1.1.2",
+    "version": "1.2.0",
     "url": "https://github.com/PumpedSardines/Tajpi/releases/tag/1.1.2"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+## 1.2.0
+Separated "transform sx and sh" to two diffrent options "transform sx" and "transform sh"

--- a/Tajpi.xcodeproj/project.pbxproj
+++ b/Tajpi.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		80B2740F27A3E95F005B451F /* Esperanto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Esperanto.swift; sourceTree = "<group>"; };
 		80B2741127A3E97E005B451F /* Swedish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swedish.swift; sourceTree = "<group>"; };
 		80B2741427A3F1B8005B451F /* version */ = {isa = PBXFileReference; lastKnownFileType = text; path = version; sourceTree = "<group>"; };
+		80B428EB2876D3B500C62C3F /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +70,7 @@
 		80B273CA27A2AAD2005B451F = {
 			isa = PBXGroup;
 			children = (
+				80B428EB2876D3B500C62C3F /* CHANGELOG.md */,
 				80B273F927A2B2A0005B451F /* README.md */,
 				808CDE8927A3F82C00B7ADBF /* GIVE_ACCESS.md */,
 				808CDE8727A3F44B00B7ADBF /* .gitignore */,
@@ -414,7 +416,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fritiof-rusck.Tajpi";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -444,7 +446,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fritiof-rusck.Tajpi";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Tajpi/AppDelegate/AppDelegate.swift
+++ b/Tajpi/AppDelegate/AppDelegate.swift
@@ -172,8 +172,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupMenus()
     }
     
-    @objc func setAutomaticTransformMode() {
-        automaticTransform.change(!automaticTransform.value);
+    @objc func setAutomaticTransformModeX() {
+        automaticTransformX.change(!automaticTransformX.value);
+        setupMenus()
+    }
+    
+    @objc func setAutomaticTransformModeH() {
+        automaticTransformH.change(!automaticTransformH.value);
         setupMenus()
     }
     
@@ -181,22 +186,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let menu = NSMenu();
         menu.autoenablesItems = true
         
-        // Init eng button
+        // Init option mode button
         let optionButton = NSMenuItem(title: locale.value.modeOption(), action: #selector(setOptionMode) , keyEquivalent: "")
         optionButton.state = .off
         if(option.value) {
             optionButton.state = .on
         }
         
-        // Init eo button
-        let automaticTransformButton = NSMenuItem(title: locale.value.modeAutomaticTransform(), action: #selector(setAutomaticTransformMode) , keyEquivalent: "")
-        automaticTransformButton.state = .off
-        if(automaticTransform.value) {
-            automaticTransformButton.state = .on
+        // Init transform X button
+        let automaticTransformButtonX = NSMenuItem(title: locale.value.modeAutomaticTransformX(), action: #selector(setAutomaticTransformModeX) , keyEquivalent: "")
+        automaticTransformButtonX.state = .off
+        if(automaticTransformX.value) {
+            automaticTransformButtonX.state = .on
+        }
+        
+        // Init transform H button
+        let automaticTransformButtonH = NSMenuItem(title: locale.value.modeAutomaticTransformH(), action: #selector(setAutomaticTransformModeH) , keyEquivalent: "")
+        automaticTransformButtonH.state = .off
+        if(automaticTransformH.value) {
+            automaticTransformButtonH.state = .on
         }
         
         menu.addItem(optionButton);
-        menu.addItem(automaticTransformButton);
+        menu.addItem(automaticTransformButtonX);
+        menu.addItem(automaticTransformButtonH);
         
         return menu
     }

--- a/Tajpi/KeyboardInterception/KeyboardInterception.swift
+++ b/Tajpi/KeyboardInterception/KeyboardInterception.swift
@@ -13,7 +13,8 @@ import Swift
 
 var paused = BoolState(id: "keyboard.pause", value: false);
 var option = BoolState(id: "keyboard.option", value: true);
-var automaticTransform = BoolState(id: "keyboard.automaticTransform", value: false);
+var automaticTransformX = BoolState(id: "keyboard.automaticTransformX", value: false);
+var automaticTransformH = BoolState(id: "keyboard.automaticTransformH", value: false);
 
 private var loop: CFRunLoop? = nil;
 private var loopSource: CFRunLoopSource? = nil;

--- a/Tajpi/LocaleManager/Locales/English.swift
+++ b/Tajpi/LocaleManager/Locales/English.swift
@@ -34,8 +34,12 @@ struct English: Locale {
         return "option + key";
     }
     
-    func modeAutomaticTransform() -> String {
-        return "Transform sh and sx";
+    func modeAutomaticTransformX() -> String {
+        return "Transform sx";
+    }
+    
+    func modeAutomaticTransformH() -> String {
+        return "Transform sh";
     }
     
     func updateAvailable() -> String {

--- a/Tajpi/LocaleManager/Locales/Esperanto.swift
+++ b/Tajpi/LocaleManager/Locales/Esperanto.swift
@@ -34,8 +34,12 @@ struct Esperanto: Locale {
         return "option + klavo";
     }
     
-    func modeAutomaticTransform() -> String {
-        return "Transformu sh kaj sx";
+    func modeAutomaticTransformH() -> String {
+        return "Transformu sh";
+    }
+    
+    func modeAutomaticTransformX() -> String {
+        return "Transformu sx";
     }
     
     func updateAvailable() -> String {

--- a/Tajpi/LocaleManager/Locales/Locale.swift
+++ b/Tajpi/LocaleManager/Locales/Locale.swift
@@ -10,19 +10,20 @@ import Foundation
 protocol Locale {
     var name: String { get };
     
-     func state(paused: Bool) -> String;
-     func changeState(paused: Bool) -> String;
+    func state(paused: Bool) -> String;
+    func changeState(paused: Bool) -> String;
     
-     func modes() -> String;
-     func modeOption() -> String;
-     func modeAutomaticTransform() -> String;
+    func modes() -> String;
+    func modeOption() -> String;
+    func modeAutomaticTransformX() -> String;
+    func modeAutomaticTransformH() -> String;
     
-     func updateAvailable() -> String;
-     func currentVersion(version: String) -> String;
-     func foundABug() -> String;
-     func changeLanguage() -> String;
+    func updateAvailable() -> String;
+    func currentVersion(version: String) -> String;
+    func foundABug() -> String;
+    func changeLanguage() -> String;
     
-     func quit() -> String;
+    func quit() -> String;
     
     func missingPermissions() -> String;
     func fixMissingPermisions() -> String;

--- a/Tajpi/LocaleManager/Locales/Swedish.swift
+++ b/Tajpi/LocaleManager/Locales/Swedish.swift
@@ -34,8 +34,12 @@ struct Swedish: Locale {
         return "option + tangent";
     }
     
-    func modeAutomaticTransform() -> String {
-        return "Gör om sh and sx";
+    func modeAutomaticTransformX() -> String {
+        return "Gör om sx";
+    }
+    
+    func modeAutomaticTransformH() -> String {
+        return "Gör om sh";
     }
     
     func updateAvailable() -> String {


### PR DESCRIPTION
Instead of having a single options to transform the key combination of "sx or sh" to ŝ. The different key combinations sx and sh are divided into two different options.